### PR TITLE
Git log: R key for interactive rebase on selected commit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ through these hashes and interact with them using the following key commands:
 * <kbd>enter</kbd>, <kbd>f</kbd> - view diff of selected hash.
   * specifically, this runs `git -c core.pager='less -+F' show -w <commit>`.
 * <kbd>c</kbd> - checkout the selected hash.
+* <kbd>r</kbd> - perform an interactive rebase from this commit.
 * <kbd>y</kbd> - copy the selected hash to the clipboard.
 
 ### `status`
@@ -158,7 +159,7 @@ filenames for `gilt status` or `gilt status -s`.
 To get set up for development, simply clone the repo and `yarn install` and
 you should be good to go.
 
-`yarn prepublish` will create the output command in `lib/index.js` which you
+`yarn prepublishOnly` will create the output command in `lib/index.js` which you
 can run as an executable.
 
 I recommend running `yarn link` to link the repository for local development

--- a/src/__tests__/Gilt.test.ts
+++ b/src/__tests__/Gilt.test.ts
@@ -60,7 +60,7 @@ describe('Gilt', () => {
     listeners['enter']();
     listeners['y']();
 
-    expect(navigator.key).toHaveBeenCalledTimes(7);
+    expect(navigator.key).toHaveBeenCalledTimes(8);
     expect(navigator.navigateNext).toHaveBeenCalledTimes(1);
     expect(navigator.navigatePrev).toHaveBeenCalledTimes(1);
     expect(navigator.clear).toHaveBeenCalledTimes(1);

--- a/src/command/LogCommand.ts
+++ b/src/command/LogCommand.ts
@@ -34,5 +34,18 @@ export class LogCommand extends Command {
       // FIXME handle at the program level
       process.exit();
     });
+
+    this.navigator.key(['r'], () => {
+      this.program
+        .spawn('git', [
+          'rebase',
+          '-i',
+          // To perform an interactive rebase from the selected commit, we need
+          // to go back one additional commit -- hence the '%'
+          this.navigator.getSelectedBlock().block + '^',
+          // FIXME handle at the program level
+        ])
+        .on('close', () => process.exit());
+    });
   }
 }

--- a/src/command/Program.ts
+++ b/src/command/Program.ts
@@ -1,3 +1,5 @@
+import { ChildProcess } from 'child_process';
+
 /**
  * Interface that represents the running program and handles high level
  * program commands and content handling
@@ -19,5 +21,5 @@ export interface Program {
   /**
    * Spawn a separate process
    */
-  spawn(command: string, args?: string[], options?: {});
+  spawn(command: string, args?: string[], options?: {}): ChildProcess;
 }

--- a/src/command/gilt/GiltProgram.ts
+++ b/src/command/gilt/GiltProgram.ts
@@ -1,5 +1,5 @@
 import { Program } from '../Program';
-import { spawn, spawnSync } from 'child_process';
+import { spawn, spawnSync, ChildProcess } from 'child_process';
 import { Widgets, escape } from 'blessed';
 
 export class GiltProgram implements Program {
@@ -34,7 +34,7 @@ export class GiltProgram implements Program {
     pbcopy.stdin.end();
   }
 
-  spawn(command, args = [], options = {}) {
-    this.screen.spawn(command, args, options);
+  spawn(command, args = [], options = {}): ChildProcess {
+    return this.screen.spawn(command, args, options);
   }
 }


### PR DESCRIPTION
`git log`: <kbd>r</kbd> does interactive rebase from the selected commit (inclusive).

To get this to work properly, I had to wait until the spawned process actually closes before exiting the parent, gilt. Otherwise, git complains that it can't run the editor